### PR TITLE
fix(profile): autofill alumni name and email fields during profile cr…

### DIFF
--- a/app/Http/Controllers/AlumniProfileController.php
+++ b/app/Http/Controllers/AlumniProfileController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\User;
 use Illuminate\Http\Request;
 use App\Models\AlumniProfile;
 use Illuminate\Support\Facades\Auth;
@@ -48,8 +49,21 @@ class AlumniProfileController extends Controller implements HasMiddleware
 
     public function create()
     {
-        return view('alumni.profile.create');
+        $alumni = Auth::user();  
+    
+       
+        $name = $alumni->name;
+        $last_name = $alumni->last_name;
+        $email = $alumni->email;
+
+        return view('alumni.profile.create', [
+            'name' => $name,
+            'last_name' => $last_name,
+            'email' => $email
+        ]);
     }
+    
+    
 
     public function store(Request $request)
     {

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -101,6 +101,7 @@ class UserController extends Controller implements HasMiddleware
         $request->validate(
             [
                 'name' => 'required|string|max:255',
+                'lname' => 'required|string|max:255',
                 'email' => 'required|email|max:255|unique:users,email',
                 'password' => [
                     'required',
@@ -119,6 +120,7 @@ class UserController extends Controller implements HasMiddleware
 
         $user = User::create([
             'name' => $request->name,
+            'last_name' => $request->lname,
             'email' => $request->email,
             'password' => Hash::make($request->password),
             'activation_token' => Str::random(60),

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -31,6 +31,7 @@ class User extends Authenticatable implements MustVerifyEmail
 
     protected $fillable = [
         'name',
+        'last_name',
         'email',
         'password',
         'activation_token',

--- a/database/migrations/2024_09_10_090136_add_lastname__user.php
+++ b/database/migrations/2024_09_10_090136_add_lastname__user.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('last_name')->nullable()->after('name');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('last_name');
+        });
+    }
+};

--- a/database/migrations/2024_09_11_082825_education.php
+++ b/database/migrations/2024_09_11_082825_education.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        //
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        //
+    }
+};

--- a/resources/views/alumni/profile/create.blade.php
+++ b/resources/views/alumni/profile/create.blade.php
@@ -48,9 +48,16 @@
                     <div class="mb-4">
                         <label for="full_name"
                             class="required block text-sm font-medium text-gray-700">{{ __('Full Name') }}</label>
+
+
+
+
                         <input id="full_name" type="text" placeholder="Enter Your Full Name" name="full_name"
-                            value="{{ old('full_name') }}" autocomplete="full_name" autofocus
+                           readonly value="{{ $name}} {{ $last_name}}" 
                             class="mt-1 block w-full border rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-red-500 focus:border-red-500 sm:text-sm required-input @error('full_name') border-red-500 @enderror">
+
+
+
                         @error('full_name')
                             <span class="text-sm text-red-500">{{ $message }}</span>
                         @enderror
@@ -71,13 +78,12 @@
                         <label for="email"
                             class="required block text-sm font-medium text-gray-700">{{ __('Email Address') }}</label>
                         <input id="email" type="email" placeholder="Enter Your Email" name="email"
-                            value="{{ old('email') }}" autocomplete="email"
+                            readonly value="{{ $email}}"
                             class="mt-1 block w-full border  rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-red-500 focus:border-red-500 sm:text-sm required-input @error('email') border-red-500 @enderror">
                         @error('email')
                             <span class="text-sm text-red-500">{{ $message }}</span>
                         @enderror
-                    </div>
-
+                    </div> 
                     <div class="mb-4">
                         <label for="profile_photo"
                             class="required block text-sm font-medium text-gray-700">{{ __('Profile Image') }}</label>
@@ -87,6 +93,7 @@
                             <span class="text-sm text-red-500">{{ $message }}</span>
                         @enderror
                     </div>
+
                 </div>
 
                 {{-- Education --}}

--- a/resources/views/role-permission/user/create.blade.php
+++ b/resources/views/role-permission/user/create.blade.php
@@ -31,8 +31,15 @@
 
 
                             <div>
-                                <x-input-label for="name" :value="__('Name')" />
+                                <x-input-label for="name" :value="__('First Name')" />
                                 <x-text-input id="name" class="block mt-1 w-full" type="text" name="name"
+                                    :value="old('name')" required autofocus autocomplete="name" />
+                                <x-input-error :messages="$errors->get('name')" class="mt-2" />
+                            </div>
+
+                            <div>
+                                <x-input-label for="lname" :value="__('Last Name')" />
+                                <x-text-input id="lname" class="block mt-1 w-full" type="text" name="lname"
                                     :value="old('name')" required autofocus autocomplete="name" />
                                 <x-input-error :messages="$errors->get('name')" class="mt-2" />
                             </div>


### PR DESCRIPTION
This PR addresses an issue where alumni name and email fields were not being auto-filled during profile creation. The feature now automatically populates these fields when the alumni user is logged in, improving the user experience and reducing manual input errors.

Changes Introduced:
Auto-populate alumni name and email fields in the profile creation form.
Fetch user details from the session or database when the profile creation page loads.
Ensure the fields are read-only to prevent unintended modifications.
Fixes:
Resolves an issue where users had to manually enter their name and email, even when the system already had this information.
Technical Details:
The logged-in alumni details are retrieved from the session.
Updated the ProfileController to pass the logged-in user's data to the view.
Adjusted the form in create.blade.php to display the name and email as pre-filled, non-editable fields.
Testing:
Manually tested the autofill functionality with various alumni accounts to ensure the name and email are correctly populated.
Verified that the fields are non-editable and correctly display the user’s information.
Screenshots: